### PR TITLE
Welcome email on registration

### DIFF
--- a/ufa_picks/app.py
+++ b/ufa_picks/app.py
@@ -88,6 +88,7 @@ def register_commands(app):
     app.cli.add_command(commands.sync_db)
     app.cli.add_command(commands.dummy_data)
     app.cli.add_command(commands.send_reminders)
+    app.cli.add_command(commands.send_welcome)
 
 
 def configure_logger(app):

--- a/ufa_picks/commands.py
+++ b/ufa_picks/commands.py
@@ -187,6 +187,27 @@ def sync_db(table, all_tables):
     _perform_sync_insert(prod_engine, prod_metadata, tables_to_sync, qa_password_hash)
 
     db.session.commit()
+
+    # 3. Sync sequences from prod so dev IDs don't collide after insert
+    # Read MAX(id) from the table rather than last_value from the sequence
+    # to avoid needing SELECT privilege on the sequence objects.
+    sequence_tables = [
+        ("picks_id_seq", "picks"),
+        ("roles_id_seq", "roles"),
+        ("users_id_seq", "users"),
+    ]
+    with prod_engine.connect() as prod_conn:
+        with db.engine.connect() as dev_conn:
+            for seq, table in sequence_tables:
+                try:
+                    row = prod_conn.execute(text(f"SELECT COALESCE(MAX(id), 1) FROM {table}")).fetchone()
+                    if row:
+                        dev_conn.execute(text(f"SELECT setval('{seq}', :val)"), {"val": row[0]})
+                        dev_conn.commit()
+                        click.echo(f"Synced sequence {seq} to {row[0]}")
+                except Exception as e:
+                    click.echo(f"  -> Warning: Could not sync sequence {seq}: {e}")
+
     click.echo("Database sync complete.")
 
 

--- a/ufa_picks/commands.py
+++ b/ufa_picks/commands.py
@@ -384,6 +384,34 @@ def dummy_data():
     click.echo("Done!")
 
 
+@click.command("send-welcome")
+@click.option("--dry-run", is_flag=True, help="Print without sending")
+@click.option("--username", default=None, help="Send only to this username")
+def send_welcome(dry_run, username):
+    """Send the welcome email to existing users who never received one."""
+    from ufa_picks.email_utils import send_welcome_email
+    from ufa_picks.user.models import User
+
+    if username:
+        users = User.query.filter_by(username=username, active=True).all()
+        if not users:
+            click.echo(f"No active user found with username '{username}'.")
+            return
+    else:
+        users = User.query.filter_by(active=True).order_by(User.id).all()
+
+    click.echo(f"Sending welcome email to {len(users)} user(s)...")
+    for user in users:
+        if dry_run:
+            click.echo(f"[DRY RUN] Would send to {user.username} <{user.email}>")
+            continue
+        try:
+            send_welcome_email(user, new_user=False)
+            click.echo(f"Sent to {user.username} <{user.email}>")
+        except Exception as e:
+            click.echo(f"Failed for {user.username}: {e}")
+
+
 @click.command("send-reminders")
 @click.option("--year", default=None, help="Season year (defaults to current year)")
 @click.option("--dry-run", is_flag=True, help="Print emails without sending")

--- a/ufa_picks/commands.py
+++ b/ufa_picks/commands.py
@@ -200,9 +200,13 @@ def sync_db(table, all_tables):
         with db.engine.connect() as dev_conn:
             for seq, table in sequence_tables:
                 try:
-                    row = prod_conn.execute(text(f"SELECT COALESCE(MAX(id), 1) FROM {table}")).fetchone()
+                    row = prod_conn.execute(
+                        text(f"SELECT COALESCE(MAX(id), 1) FROM {table}")
+                    ).fetchone()
                     if row:
-                        dev_conn.execute(text(f"SELECT setval('{seq}', :val)"), {"val": row[0]})
+                        dev_conn.execute(
+                            text(f"SELECT setval('{seq}', :val)"), {"val": row[0]}
+                        )
                         dev_conn.commit()
                         click.echo(f"Synced sequence {seq} to {row[0]}")
                 except Exception as e:
@@ -258,8 +262,10 @@ def _perform_sync_insert(prod_engine, prod_metadata, tables_to_sync, qa_password
                             if "password" in row_dict:
                                 row_dict["password"] = qa_password_hash
                             if "email" in row_dict:
-                                row_dict["email"] = f"test+{row_dict.get('first_name', 'user').lower().strip()}"\
-                                                    f"{row_dict['id']}@razator.com"
+                                row_dict["email"] = (
+                                    f"test+{row_dict.get('first_name', 'user').lower().strip()}"
+                                    f"{row_dict['id']}@razator.com"
+                                )
                         insert_data.append(row_dict)
 
                     chunk_size = 500
@@ -386,7 +392,9 @@ def dummy_data():
 
 @click.command("send-welcome")
 @click.option("--dry-run", is_flag=True, help="Print without sending")
-@click.option("--username", default=None, help="Comma-separated list of usernames to send to")
+@click.option(
+    "--username", default=None, help="Comma-separated list of usernames to send to"
+)
 def send_welcome(dry_run, username):
     """Send the welcome email to existing users who never received one."""
     from ufa_picks.email_utils import send_welcome_email
@@ -394,7 +402,7 @@ def send_welcome(dry_run, username):
 
     if username:
         names = [n.strip() for n in username.split(",") if n.strip()]
-        users = User.query.filter(User.username.in_(names), User.active == True).all()
+        users = User.query.filter(User.username.in_(names), User.active.is_(True)).all()
         found = {u.username for u in users}
         for name in names:
             if name not in found:
@@ -419,7 +427,9 @@ def send_welcome(dry_run, username):
 @click.command("send-reminders")
 @click.option("--year", default=None, help="Season year (defaults to current year)")
 @click.option("--dry-run", is_flag=True, help="Print emails without sending")
-@click.option("--force", is_flag=True, help="Send regardless of timing (bypass day-before check)")
+@click.option(
+    "--force", is_flag=True, help="Send regardless of timing (bypass day-before check)"
+)
 def send_reminders(year, dry_run, force):
     """Send weekly reminder emails to opted-in users.
 
@@ -477,7 +487,9 @@ def send_reminders(year, dry_run, force):
     click.echo(f"Upcoming week: {upcoming_week_num}, Previous week: {prev_week_num}")
 
     # Build leaderboard data
-    prev_week_lb = get_leaderboard_cache(year, week=prev_week_num) if prev_week_num else []
+    prev_week_lb = (
+        get_leaderboard_cache(year, week=prev_week_num) if prev_week_num else []
+    )
     season_lb = get_leaderboard_cache(year)
     top3_prev = prev_week_lb[:3]
     season_rank_map = {entry["user"].id: entry["rank"] for entry in season_lb}
@@ -492,11 +504,13 @@ def send_reminders(year, dry_run, force):
         for p in all_players:
             breakdown = p.get_weekly_breakdown(year)
             reg = [
-                item for item in breakdown
+                item
+                for item in breakdown
                 if item["week"] <= two_weeks_ago and not item["is_playoff"]
             ]
             playoff = [
-                item for item in breakdown
+                item
+                for item in breakdown
                 if item["week"] <= two_weeks_ago and item["is_playoff"]
             ]
             # Re-derive dropped week for this slice (same logic as the model)
@@ -516,7 +530,9 @@ def send_reminders(year, dry_run, force):
     opted_in = User.query.filter_by(active=True, get_email_reminder=True).all()
     click.echo(f"Opted-in users: {len(opted_in)}")
 
-    picks_url = url_for("game.week", year=year, week_num=upcoming_week_num, _external=True)
+    picks_url = url_for(
+        "game.week", year=year, week_num=upcoming_week_num, _external=True
+    )
     leaderboard_url = url_for("user.members", _external=True)
 
     for user in opted_in:
@@ -531,7 +547,9 @@ def send_reminders(year, dry_run, force):
 
         current_rank = season_rank_map.get(user.id)
         prior_rank = prior_rank_map.get(user.id)
-        rank_change = (prior_rank - current_rank) if (prior_rank and current_rank) else None
+        rank_change = (
+            (prior_rank - current_rank) if (prior_rank and current_rank) else None
+        )
 
         context = {
             "user": user,

--- a/ufa_picks/commands.py
+++ b/ufa_picks/commands.py
@@ -386,16 +386,20 @@ def dummy_data():
 
 @click.command("send-welcome")
 @click.option("--dry-run", is_flag=True, help="Print without sending")
-@click.option("--username", default=None, help="Send only to this username")
+@click.option("--username", default=None, help="Comma-separated list of usernames to send to")
 def send_welcome(dry_run, username):
     """Send the welcome email to existing users who never received one."""
     from ufa_picks.email_utils import send_welcome_email
     from ufa_picks.user.models import User
 
     if username:
-        users = User.query.filter_by(username=username, active=True).all()
+        names = [n.strip() for n in username.split(",") if n.strip()]
+        users = User.query.filter(User.username.in_(names), User.active == True).all()
+        found = {u.username for u in users}
+        for name in names:
+            if name not in found:
+                click.echo(f"No active user found with username '{name}'.")
         if not users:
-            click.echo(f"No active user found with username '{username}'.")
             return
     else:
         users = User.query.filter_by(active=True).order_by(User.id).all()

--- a/ufa_picks/email_utils.py
+++ b/ufa_picks/email_utils.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 """Email utility functions."""
+import datetime as dt
 import smtplib
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
-from flask import current_app, render_template
+from flask import current_app, render_template, url_for
 
 
 def send_email(recipients, subject, html_body, text_body=None):
@@ -47,6 +48,40 @@ def send_email(recipients, subject, html_body, text_body=None):
     except Exception as e:
         current_app.logger.exception(f"Failed to send email to {recipients}: {e}")
         raise
+
+
+def send_welcome_email(user):
+    """Send a welcome email to a newly registered user."""
+    from ufa_picks.game.models import Game
+
+    year = str(dt.datetime.now().year)
+    now = dt.datetime.now(dt.timezone.utc).replace(tzinfo=None)
+    upcoming = (
+        Game.query.filter(Game.season == year, Game.start_timestamp > now)
+        .order_by(Game.week)
+        .first()
+    )
+
+    picks_url = None
+    week_num = None
+    if upcoming:
+        week_num = upcoming.week
+        picks_url = url_for("game.week", year=year, week_num=week_num, _external=True)
+
+    profile_url = url_for("user.edit_profile", _external=True)
+
+    html_body = render_template(
+        "emails/welcome.html",
+        user=user,
+        picks_url=picks_url,
+        week_num=week_num,
+        profile_url=profile_url,
+    )
+    send_email(
+        recipients=user.email,
+        subject="Welcome to UFA Picks!",
+        html_body=html_body,
+    )
 
 
 def send_temp_password_email(user, temp_password):

--- a/ufa_picks/email_utils.py
+++ b/ufa_picks/email_utils.py
@@ -76,7 +76,7 @@ def send_welcome_email(user, new_user=True):
         picks_url=picks_url,
         week_num=week_num,
         profile_url=profile_url,
-        new_user=new_user
+        new_user=new_user,
     )
     send_email(
         recipients=user.email,

--- a/ufa_picks/email_utils.py
+++ b/ufa_picks/email_utils.py
@@ -50,7 +50,7 @@ def send_email(recipients, subject, html_body, text_body=None):
         raise
 
 
-def send_welcome_email(user):
+def send_welcome_email(user, new_user=True):
     """Send a welcome email to a newly registered user."""
     from ufa_picks.game.models import Game
 
@@ -76,6 +76,7 @@ def send_welcome_email(user):
         picks_url=picks_url,
         week_num=week_num,
         profile_url=profile_url,
+        new_user=new_user
     )
     send_email(
         recipients=user.email,

--- a/ufa_picks/public/forms.py
+++ b/ufa_picks/public/forms.py
@@ -53,5 +53,8 @@ class ChangePasswordForm(FlaskForm):
     )
     confirm = PasswordField(
         "Confirm New Password",
-        validators=[DataRequired(), EqualTo("new_password", message="Passwords must match")],
+        validators=[
+            DataRequired(),
+            EqualTo("new_password", message="Passwords must match"),
+        ],
     )

--- a/ufa_picks/public/views.py
+++ b/ufa_picks/public/views.py
@@ -4,8 +4,6 @@ import datetime as dt
 import secrets
 import string
 
-from sqlalchemy import func
-
 from flask import (
     Blueprint,
     current_app,
@@ -16,6 +14,7 @@ from flask import (
     url_for,
 )
 from flask_login import current_user, login_required, login_user, logout_user
+from sqlalchemy import func
 
 from ufa_picks.email_utils import send_temp_password_email, send_welcome_email
 from ufa_picks.extensions import login_manager
@@ -94,7 +93,9 @@ def register():
         try:
             send_welcome_email(user)
         except Exception:
-            current_app.logger.exception("Failed to send welcome email to %s", user.email)
+            current_app.logger.exception(
+                "Failed to send welcome email to %s", user.email
+            )
         flash("Thank you for registering. You can now log in.", "success")
         return redirect(url_for("public.home"))
     else:
@@ -130,7 +131,9 @@ def forgot_password():
             "info",
         )
         return redirect(url_for("public.home"))
-    return render_template("public/forgot_password.html", form=form, forgot_form=forgot_form)
+    return render_template(
+        "public/forgot_password.html", form=form, forgot_form=forgot_form
+    )
 
 
 @blueprint.route("/change-password/", methods=["GET", "POST"])

--- a/ufa_picks/public/views.py
+++ b/ufa_picks/public/views.py
@@ -17,7 +17,7 @@ from flask import (
 )
 from flask_login import current_user, login_required, login_user, logout_user
 
-from ufa_picks.email_utils import send_temp_password_email
+from ufa_picks.email_utils import send_temp_password_email, send_welcome_email
 from ufa_picks.extensions import login_manager
 from ufa_picks.game.models import Game
 from ufa_picks.public.forms import ChangePasswordForm, ForgotPasswordForm, LoginForm
@@ -81,22 +81,25 @@ def logout():
 @blueprint.route("/register/", methods=["GET", "POST"])
 def register():
     """Register new user."""
-    form = LoginForm(request.form)
     register_form = RegisterForm(request.form)
-    if form.validate_on_submit():
-        User.create(
-            username=form.username.data,
-            first_name=form.first_name.data,
-            last_name=form.last_name.data,
-            email=form.email.data,
-            password=form.password.data,
+    if register_form.validate_on_submit():
+        user = User.create(
+            username=register_form.username.data,
+            first_name=register_form.first_name.data,
+            last_name=register_form.last_name.data,
+            email=register_form.email.data,
+            password=register_form.password.data,
             active=True,
         )
+        try:
+            send_welcome_email(user)
+        except Exception:
+            current_app.logger.exception("Failed to send welcome email to %s", user.email)
         flash("Thank you for registering. You can now log in.", "success")
         return redirect(url_for("public.home"))
     else:
-        flash_errors(form)
-    return render_template("public/register.html", form=form, register_form=register_form)
+        flash_errors(register_form)
+    return render_template("public/register.html", register_form=register_form)
 
 
 @blueprint.route("/forgot-password/", methods=["GET", "POST"])

--- a/ufa_picks/templates/emails/welcome.html
+++ b/ufa_picks/templates/emails/welcome.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <style>
+    body { font-family: Arial, sans-serif; color: #333; max-width: 600px; margin: 0 auto; }
+    h2 { color: #1a1a2e; }
+    h3 { color: #333; border-bottom: 1px solid #eee; padding-bottom: 6px; }
+    .cta { display: inline-block; background: #0d6efd; color: #fff !important; padding: 12px 24px; border-radius: 6px; text-decoration: none; font-weight: bold; margin: 12px 0; }
+    .tip-box { background: #f8f9fa; border-left: 4px solid #0d6efd; padding: 12px 16px; border-radius: 0 6px 6px 0; margin: 16px 0; }
+    .footer { margin-top: 32px; font-size: 12px; color: #888; border-top: 1px solid #eee; padding-top: 16px; }
+  </style>
+</head>
+<body>
+  <h2>Welcome to UFA Picks, {{ user.first_name }}!</h2>
+
+  <p>Thanks for joining our UFA Picks game. Each week you'll pick the winners and scores of UFA games — the more you get right,
+    the more points you earn. The picks each week will lock at the start of the first game of the week. So you can't edit
+    other games in the week once that first game starts. Once picks are locked you'll be able to click on the game and
+    see what the other players picked.
+  </p>
+  <p>You can also follow other users to create a friends ranking. You will be able to see how you stack up against players you follow. 
+    Feel free to invite your friends to join. This is just for fun and the prizes will be for overall placements.
+  </p>
+
+  <h3>How Scoring Works</h3>
+  <ul>
+    <li><strong>3 points</strong> for correctly picking the winning team</li>
+    <li><strong>Up to 2 bonus points</strong> (1 per team) for guessing the exact final score</li>
+    <li><strong>1 bonus point</strong> for guessing the exact margin of victory</li>
+  </ul>
+  <p>At the end of the regular season your lowest-scoring week is automatically dropped, so one rough week won't sink you.</p>
+
+  <h3>Prizes</h3>
+  <ul>
+    <li><strong>1st place</strong> — Jersey of your choice</li>
+    <li><strong>2nd &amp; 3rd place</strong> — Utah Jazz or Utah Mammoth hat</li>
+  </ul>
+
+  {% if picks_url %}
+  <h3>Get Your Picks In</h3>
+  <p>Week {{ week_num }} is open now. Don't miss it!</p>
+  <a href="{{ picks_url }}" class="cta">Submit Week {{ week_num }} Picks</a>
+  {% endif %}
+
+  <div class="tip-box">
+    <strong>Weekly reminders:</strong> Want a nudge before picks lock each week?
+    You can opt in to weekly reminder emails from your
+    <a href="{{ profile_url }}">profile settings</a>.
+  </div>
+
+  <p>Good luck this season!</p>
+
+  <div class="footer">
+    If you see any bugs or issues with the site let me know, ryan@razator.com.
+    You're receiving this because you just created a UFA Picks account.
+  </div>
+</body>
+</html>

--- a/ufa_picks/templates/emails/welcome.html
+++ b/ufa_picks/templates/emails/welcome.html
@@ -20,7 +20,8 @@
     see what the other players picked.
   </p>
   <p>You can also follow other users to create a friends ranking. You will be able to see how you stack up against players you follow. 
-    Feel free to invite your friends to join. This is just for fun and the prizes will be for overall placements.
+    Feel free to invite your friends to join. This is just for fun (and more importantly to heckle your friends when you beat them)
+    and the prizes will be for overall placements.
   </p>
 
   <h3>How Scoring Works</h3>
@@ -53,7 +54,9 @@
 
   <div class="footer">
     If you see any bugs or issues with the site let me know, ryan@razator.com.
+    {% if new_user %}
     You're receiving this because you just created a UFA Picks account.
+    {% endif %}
   </div>
 </body>
 </html>

--- a/ufa_picks/user/forms.py
+++ b/ufa_picks/user/forms.py
@@ -59,7 +59,10 @@ class EditProfileForm(FlaskForm):
     )
     confirm_new_password = PasswordField(
         "Confirm New Password",
-        validators=[Optional(), EqualTo("new_password", message="Passwords must match")],
+        validators=[
+            Optional(),
+            EqualTo("new_password", message="Passwords must match"),
+        ],
     )
     get_email_reminder = BooleanField("Send me weekly email reminders")
 


### PR DESCRIPTION
## Summary

- Sends a welcome email when a new user registers, including scoring rules, prizes, and a link to the current week's picks if one is open
- Fixes a registration bug where the login form was being validated instead of the register form
- Adds a `send-welcome` CLI command to backfill existing users who never received a welcome email (supports `--dry-run` and `--username alice,bob` options)
- Fixes `sync-db` to update PostgreSQL sequences from prod after data sync, preventing ID collisions during testing

## Test plan

- [x] Register a new account and confirm welcome email is received
- [x] Confirm registration form works correctly (no longer tries to log in)
- [x] Run `flask send-welcome --dry-run` and verify expected users are listed
- [x] Run `flask send-welcome --username <name> --dry-run` and verify only that user is listed
- [x] Run `flask sync-db -t users` and confirm sequences are synced without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)