### PR TITLE
Add dedicated login page

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,3 +214,18 @@ in ``.env``:
 ```text
 SEND_FILE_MAX_AGE_DEFAULT=31556926  # one year
 ```
+
+## Manage Command Reference
+
+All commands are run as `docker compose run --rm manage <command>`.
+
+| Command | Options | Description |
+|---|---|---|
+| `db init` / `db migrate` / `db upgrade` | | Database migrations |
+| `shell` | | Interactive Flask shell |
+| `test` | `--no-coverage`, `-k <expr>` | Run test suite |
+| `lint` | `--check` | Lint and format code |
+| `sync-db` | `--all-tables` / `-t <table>` | Sync dev DB from production |
+| `dummy-data` | | Seed DB with simulated games and picks |
+| `send-welcome` | `--username <name>`, `--dry-run` | Send welcome email to existing users |
+| `send-reminders` | `--year <year>`, `--force`, `--dry-run` | Send weekly reminder emails to opted-in users |

--- a/ufa_picks/public/views.py
+++ b/ufa_picks/public/views.py
@@ -26,6 +26,8 @@ from ufa_picks.utils import flash_errors
 
 blueprint = Blueprint("public", __name__, static_folder="../static")
 
+login_manager.login_view = "public.login"
+
 
 @login_manager.user_loader
 def load_user(user_id):
@@ -68,6 +70,26 @@ def home():
     )
 
 
+@blueprint.route("/login/", methods=["GET", "POST"])
+def login():
+    """Dedicated login page."""
+    if current_user.is_authenticated:
+        return redirect(url_for("user.members"))
+    form = LoginForm(request.form)
+    if request.method == "POST":
+        if form.validate_on_submit():
+            login_user(form.user)
+            if form.user.force_password_change:
+                flash("Your password is temporary. Please set a new one.", "warning")
+                return redirect(url_for("public.change_password"))
+            flash("You are logged in.", "success")
+            redirect_url = request.args.get("next") or url_for("user.members")
+            return redirect(redirect_url)
+        else:
+            flash_errors(form)
+    return render_template("public/login.html", login_form=form)
+
+
 @blueprint.route("/logout/")
 @login_required
 def logout():
@@ -106,7 +128,6 @@ def register():
 @blueprint.route("/forgot-password/", methods=["GET", "POST"])
 def forgot_password():
     """Send a temporary password to the user's email."""
-    form = LoginForm(request.form)
     forgot_form = ForgotPasswordForm(request.form)
     if request.method == "POST" and forgot_form.validate_on_submit():
         identifier = forgot_form.username_or_email.data.strip()
@@ -132,7 +153,7 @@ def forgot_password():
         )
         return redirect(url_for("public.home"))
     return render_template(
-        "public/forgot_password.html", form=form, forgot_form=forgot_form
+        "public/forgot_password.html", forgot_form=forgot_form
     )
 
 
@@ -155,5 +176,4 @@ def change_password():
 @blueprint.route("/about/")
 def about():
     """About page."""
-    form = LoginForm(request.form)
-    return render_template("public/about.html", form=form)
+    return render_template("public/about.html")

--- a/ufa_picks/templates/401.html
+++ b/ufa_picks/templates/401.html
@@ -7,7 +7,7 @@
 <div class="jumbotron">
     <div class="text-center">
         <h1>401</h1>
-        <p>You are not authorized to see this page. Please <a href="{{ url_for('public.home')}}">log in</a> or
+        <p>You are not authorized to see this page. Please <a href="{{ url_for('public.login')}}">log in</a> or
             <a href="{{ url_for('public.register') }}">create a new account</a>.
         </p>
     </div>

--- a/ufa_picks/templates/500.html
+++ b/ufa_picks/templates/500.html
@@ -8,6 +8,7 @@
     <div class="text-center">
         <h1>500</h1>
         <p>Sorry, something went wrong on our system. Don't panic, we are fixing it! Please try again later.</p>
+        <p><a href="{{ url_for('public.home') }}">Go home</a> or <a href="{{ url_for('public.login') }}">log in</a>.</p>
     </div>
 </div>
 {% endblock %}

--- a/ufa_picks/templates/public/forgot_password.html
+++ b/ufa_picks/templates/public/forgot_password.html
@@ -13,6 +13,6 @@
     </div>
     <p class="mt-3"><input class="btn btn-primary" type="submit" value="Send Temporary Password"></p>
   </form>
-  <p><em>Remember your password?</em> Click <a href="{{ url_for('public.home') }}">here</a> to log in.</p>
+  <p><em>Remember your password?</em> Click <a href="{{ url_for('public.login') }}">here</a> to log in.</p>
 </div>
 {% endblock %}

--- a/ufa_picks/templates/public/login.html
+++ b/ufa_picks/templates/public/login.html
@@ -1,0 +1,23 @@
+
+{% extends "layout.html" %}
+{% block page_title %}Login{% endblock %}
+{% block content %}
+<div class="container-narrow">
+  <h1 class="mt-5">Login</h1>
+  <br/>
+  <form id="loginForm" class="form" method="POST" action="" role="form">
+    {{ login_form.csrf_token }}
+    <div class="form-group">
+      {{ login_form.username.label }}
+      {{ login_form.username(placeholder="Username", class_="form-control") }}
+    </div>
+    <div class="form-group">
+      {{ login_form.password.label }}
+      {{ login_form.password(placeholder="Password", class_="form-control") }}
+    </div>
+    <p class="mt-3"><input class="btn btn-primary" type="submit" value="Login"></p>
+  </form>
+  <p><a href="{{ url_for('public.forgot_password') }}">Forgot your password?</a></p>
+  <p><em>Don't have an account?</em> <a href="{{ url_for('public.register') }}">Create one</a>.</p>
+</div>
+{% endblock %}

--- a/ufa_picks/templates/public/register.html
+++ b/ufa_picks/templates/public/register.html
@@ -33,7 +33,7 @@
             </div>
             <p><input class="btn btn-primary" type="submit" value="Register"></p>
     </form>
-    <p><em>Already registered?</em> Click <a href="/">here</a> to login.</p>
+    <p><em>Already registered?</em> Click <a href="{{ url_for('public.login') }}">here</a> to login.</p>
 </div>
 {% endblock %}
 


### PR DESCRIPTION
## Summary

- New `/login/` route and `login.html` template as a dedicated login page
- Nav bar login form remains on the home page only (removed from about and forgot password pages)
- `login_manager.login_view` set so `@login_required` redirects go to `/login/` with `?next=` support
- Updated 401, 500, register, and forgot password pages to link to `/login/`
- Added manage command reference table to README

## Test plan

- [x] Visit `/login/` directly and confirm the login form works
- [x] Confirm the nav bar login still appears on the home page
- [x] Confirm the nav bar login does NOT appear on the about or forgot password pages
- [x] Hit a `@login_required` route while logged out and confirm redirect to `/login/?next=...`, then confirm redirect back after login
- [x] Confirm 401 page links to `/login/`
- [x] Confirm register and forgot password pages link to `/login/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)