### PR TITLE
Add passion project disclaimer to footer and about page

### DIFF
--- a/ufa_picks/templates/footer.html
+++ b/ufa_picks/templates/footer.html
@@ -2,6 +2,7 @@
   <small>
     <ul class="company">
       <li>© Ryan Scott</li>
+      <li>This is a passion project from a fan. Please don't expect professional quality.</li>
     </ul>
 
     <ul class="footer-nav">

--- a/ufa_picks/templates/public/about.html
+++ b/ufa_picks/templates/public/about.html
@@ -5,6 +5,8 @@
 <div class="container">
     <h1 class="mt-5">About</h1>
     <div class="row">
+      <p class="lead">This site is a passion project built by a fan, for fun. It is not affiliated with the UFA in any official capacity — just a hobbyist trying to make the season a little more engaging for friends. You should not expect professional quality, guaranteed uptime, or polished design. Things may break, look rough around the edges, or change without notice. It's a labor of love, not a product.</p>
+      <p class="lead">Have feedback, found a bug, or just want to reach out? Feel free to <a href="mailto:ryan@razator.com">shoot me an email</a>.</p>
       <p class="lead">Here is the <a href="https://github.com/Razator73/ufa_picks">code</a> for this site. It has
         scores automatically updated using this <a href="https://github.com/yukikongju/audl">AUDL API</a> python package
       </p>


### PR DESCRIPTION
## Summary

- Footer now includes a short disclaimer on every page
- About page opens with a verbose disclaimer paragraph, followed by a contact paragraph
- Neither change is affiliated with or represents the UFA officially

## Test plan

- [x] Confirm disclaimer appears in the footer on all pages
- [x] Confirm about page shows disclaimer as first paragraph and contact info as second

🤖 Generated with [Claude Code](https://claude.com/claude-code)