### PR TITLE
Exclude cancelled games from views and scoring

### DIFF
--- a/migrations/versions/c4f9a1b7d2e0_cancelled_games.py
+++ b/migrations/versions/c4f9a1b7d2e0_cancelled_games.py
@@ -1,0 +1,38 @@
+"""cancelled-games
+
+Revision ID: c4f9a1b7d2e0
+Revises: b2c3d4e5f6a1
+Create Date: 2026-07-23 00:00:00.000000
+
+Adds a standalone table listing games that were cancelled. Games are refreshed
+from an external source that overwrites the ``games`` table on every load, so
+cancellations are tracked here (which the loader never touches) instead.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c4f9a1b7d2e0"
+down_revision = "b2c3d4e5f6a1"
+branch_labels = None
+depends_on = None
+
+# Games known to be cancelled at the time of this migration.
+INITIAL_CANCELLED_GAME_IDS = ["2026-07-18-PIT-CHI"]
+
+
+def upgrade():
+    cancelled_games = op.create_table(
+        "cancelled_games",
+        sa.Column("game_id", sa.String(length=18), nullable=False),
+        sa.PrimaryKeyConstraint("game_id"),
+    )
+    op.bulk_insert(
+        cancelled_games,
+        [{"game_id": game_id} for game_id in INITIAL_CANCELLED_GAME_IDS],
+    )
+
+
+def downgrade():
+    op.drop_table("cancelled_games")

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -6,7 +6,7 @@ from factory import Sequence, SubFactory
 from factory.alchemy import SQLAlchemyModelFactory
 
 from ufa_picks.database import db
-from ufa_picks.game.models import Game, Team
+from ufa_picks.game.models import CancelledGame, Game, Team
 from ufa_picks.user.models import Pick, User
 
 
@@ -79,3 +79,14 @@ class PickFactory(BaseFactory):
         """Factory configuration."""
 
         model = Pick
+
+
+class CancelledGameFactory(BaseFactory):
+    """Cancelled game factory."""
+
+    game_id = Sequence(lambda n: f"G{n}")
+
+    class Meta:
+        """Factory configuration."""
+
+        model = CancelledGame

--- a/tests/test_cancelled_games.py
+++ b/tests/test_cancelled_games.py
@@ -1,0 +1,164 @@
+# -*- coding: utf-8 -*-
+"""Tests for excluding cancelled games from views and scoring."""
+import datetime as dt
+
+import pytest
+from flask import url_for
+
+from ufa_picks.game.models import CancelledGame, Game, Team
+from ufa_picks.user.models import Pick
+
+
+@pytest.mark.usefixtures("db")
+class TestCancelledGameScoring:
+    """Cancelled games must not score or block a week from completing."""
+
+    @pytest.fixture
+    def teams(self, db):
+        """Create two teams to play the games."""
+        team_a = Team(id="A", team_city="City A", team_name="Team A")
+        team_b = Team(id="B", team_city="City B", team_name="Team B")
+        db.session.add_all([team_a, team_b])
+        db.session.commit()
+        return team_a, team_b
+
+    def _game(self, db, teams, gid, week, status="Final", home=10, away=0, days_ago=5):
+        """Create and stage a game."""
+        team_a, team_b = teams
+        game = Game(
+            id=gid,
+            home_team_id=team_a.id,
+            away_team_id=team_b.id,
+            home_score=home,
+            away_score=away,
+            status=status,
+            week=week,
+            season="2026",
+            streaming_url="",
+            has_roster_report=False,
+            start_timestamp=dt.datetime.now() - dt.timedelta(days=days_ago),
+        )
+        db.session.add(game)
+        return game
+
+    def test_cancelled_game_does_not_block_week_completion(self, db, teams, user):
+        """A cancelled (never-Final) game must not keep its week from being dropped."""
+        # Week 1 fully played: correct winner + exact score = 6 pts.
+        g1 = self._game(db, teams, "W1", week=1)
+        db.session.add(
+            Pick(user_id=user.id, game_id=g1.id, home_team_score=10, away_team_score=0)
+        )
+        # Week 2 fully played: correct winner only (no exact/margin) = 3 pts.
+        g2 = self._game(db, teams, "W2", week=2)
+        db.session.add(
+            Pick(user_id=user.id, game_id=g2.id, home_team_score=5, away_team_score=3)
+        )
+        # Week 2 also has a cancelled game that will never go Final.
+        gc = self._game(db, teams, "W2-CANCELLED", week=2, status="Upcoming")
+        db.session.add(CancelledGame(game_id=gc.id))
+        db.session.commit()
+
+        # Both weeks complete, so the lowest (week 2 = 3) is dropped -> 6 remains.
+        assert user.get_score(year="2026") == 6
+
+    def test_non_cancelled_upcoming_game_blocks_drop(self, db, teams, user):
+        """Contrast: a real Upcoming game keeps its week incomplete (not dropped)."""
+        g1 = self._game(db, teams, "N1", week=1)
+        db.session.add(
+            Pick(user_id=user.id, game_id=g1.id, home_team_score=10, away_team_score=0)
+        )  # 6 pts
+        g2 = self._game(db, teams, "N2", week=2)
+        db.session.add(
+            Pick(user_id=user.id, game_id=g2.id, home_team_score=5, away_team_score=3)
+        )  # 3 pts
+        # A normal (non-cancelled) Upcoming game leaves week 2 incomplete.
+        self._game(db, teams, "N2-PENDING", week=2, status="Upcoming")
+        db.session.commit()
+
+        # Only week 1 is complete -> nothing dropped -> 6 + 3 = 9.
+        assert user.get_score(year="2026") == 9
+
+    def test_cancelled_final_game_pick_does_not_score(self, db, teams, user):
+        """Even if a cancelled game is marked Final, its pick earns 0 points."""
+        gc = self._game(db, teams, "C-FINAL", week=4, status="Final", home=10, away=0)
+        db.session.add(CancelledGame(game_id=gc.id))
+        db.session.add(
+            Pick(user_id=user.id, game_id=gc.id, home_team_score=10, away_team_score=0)
+        )  # would be 6 pts if it counted
+        db.session.commit()
+
+        assert user.get_weekly_score("2026", 4) == 0
+        assert user.get_game_score(gc.id) == 0
+
+
+@pytest.mark.usefixtures("db")
+class TestCancelledGameViews:
+    """Cancelled games must not appear in or accept picks through the UI."""
+
+    def login(self, user, testapp):
+        """Login helper (posts to the auth route directly; CSRF is off in tests)."""
+        return testapp.post(
+            "/login/",
+            {"username": user.username, "password": "myprecious"},
+        ).follow()
+
+    def _future_game(self, db, gid, week=1):
+        """Create a future game (week not yet locked) with fresh teams."""
+        team_a = Team(id=f"{gid}A", team_city="C", team_name="N")
+        team_b = Team(id=f"{gid}B", team_city="C", team_name="N")
+        db.session.add_all([team_a, team_b])
+        future = dt.datetime.now(dt.timezone.utc).replace(tzinfo=None) + dt.timedelta(
+            days=1
+        )
+        game = Game(
+            id=gid,
+            home_team_id=team_a.id,
+            away_team_id=team_b.id,
+            status="Upcoming",
+            week=week,
+            season="2026",
+            streaming_url="",
+            has_roster_report=False,
+            start_timestamp=future,
+        )
+        db.session.add(game)
+        return game
+
+    def test_game_details_cancelled_redirects(self, user, testapp, db):
+        """Game details for a cancelled game redirects away instead of rendering."""
+        game = self._future_game(db, "DET-CANCEL")
+        db.session.add(CancelledGame(game_id=game.id))
+        db.session.commit()
+
+        self.login(user, testapp)
+        res = testapp.get(f"/games/2026/game/{game.id}").follow()
+        assert res.status_code == 200
+        assert "cancelled" in res.text.lower()
+
+    def test_update_pick_cancelled_blocked(self, user, testapp, db):
+        """The pick API rejects updates for a cancelled game."""
+        game = self._future_game(db, "PICK-CANCEL")
+        db.session.add(CancelledGame(game_id=game.id))
+        db.session.commit()
+
+        self.login(user, testapp)
+        res = testapp.post_json(
+            f"/games/update_pick/{game.id}",
+            {"home_team_score": 10, "away_team_score": 5},
+            expect_errors=True,
+        )
+        assert res.status_code == 400
+        assert "cancelled" in res.json["message"].lower()
+
+    def test_cancelled_game_excluded_from_week_view(self, user, testapp, db):
+        """A cancelled game is not listed on its week's picks page."""
+        live = self._future_game(db, "LIVE-GAME", week=1)
+        cancelled = self._future_game(db, "GONE-GAME", week=1)
+        db.session.add(CancelledGame(game_id=cancelled.id))
+        db.session.commit()
+
+        self.login(user, testapp)
+        res = testapp.get(url_for("game.week", year="2026", week_num=1))
+        assert res.status_code == 200
+        assert live.id in res.text
+        assert cancelled.id not in res.text

--- a/ufa_picks/game/models.py
+++ b/ufa_picks/game/models.py
@@ -3,6 +3,29 @@
 from ufa_picks.database import Column, Model, db, relationship
 
 
+class CancelledGame(Model):
+    """A game that was cancelled and must be excluded from views and scoring.
+
+    This lives in its own table on purpose. Game rows are refreshed from an
+    external source that overwrites the ``games`` table (including ``status``)
+    on every load, so marking the game as cancelled there would not survive a
+    sync. The loader never touches this table, so entries here persist. Adding a
+    future cancellation is a single ``INSERT`` — no code change required.
+    """
+
+    __tablename__ = "cancelled_games"
+    game_id = Column(db.String(18), primary_key=True)
+
+
+def cancelled_game_ids():
+    """Return the set of game ids that have been cancelled.
+
+    Fetch this once and reuse it within scoring/view loops rather than querying
+    per game or per pick.
+    """
+    return {c.game_id for c in CancelledGame.query.all()}
+
+
 class Team(Model):
     """A store team info."""
 
@@ -98,6 +121,11 @@ class Game(Model):
         "Team", back_populates="away_games", foreign_keys=[away_team_id]
     )
     picks = relationship("Pick", back_populates="game", lazy="dynamic")
+
+    @property
+    def is_cancelled(self):
+        """Whether this game has been cancelled (excluded from views and scoring)."""
+        return db.session.get(CancelledGame, self.id) is not None
 
     @property
     def winner(self):

--- a/ufa_picks/game/views.py
+++ b/ufa_picks/game/views.py
@@ -7,7 +7,7 @@ from flask_login import current_user, login_required
 
 from ufa_picks.extensions import db
 from ufa_picks.game.forms import GamePick
-from ufa_picks.game.models import Game
+from ufa_picks.game.models import Game, cancelled_game_ids
 from ufa_picks.user.models import Pick, User
 from ufa_picks.user.views import get_leaderboard_cache
 
@@ -43,6 +43,7 @@ def main(year):
     season = year if year else str(dt.datetime.now().year)
     games = (
         Game.query.filter_by(season=season)
+        .filter(Game.id.notin_(cancelled_game_ids()))
         .order_by(Game.week, Game.start_timestamp)
         .all()
     )
@@ -76,6 +77,7 @@ def pre_lock(year, week_num):
     token_form = GamePick(prefix="token")
     week_games = (
         Game.query.filter_by(season=year, week=week_num)
+        .filter(Game.id.notin_(cancelled_game_ids()))
         .order_by(Game.start_timestamp)
         .all()
     )
@@ -141,6 +143,12 @@ def update_pick(game_id):
     """Update a user's pick for a specific game via JSON API."""
     game = db.get_or_404(Game, game_id)
 
+    if game.is_cancelled:
+        return (
+            jsonify({"status": "error", "message": "This game has been cancelled."}),
+            400,
+        )
+
     if dt.datetime.now(dt.timezone.utc).replace(tzinfo=None) > game.start_timestamp:
         return jsonify({"status": "error", "message": "Game has already started."}), 400
 
@@ -186,6 +194,7 @@ def post_lock(year, week_num):
     """Display games and picks after the week's first game has started (read-only)."""
     week_games = (
         Game.query.filter_by(season=year, week=week_num)
+        .filter(Game.id.notin_(cancelled_game_ids()))
         .order_by(Game.start_timestamp)
         .all()
     )
@@ -218,9 +227,13 @@ def post_lock(year, week_num):
 def game_details(year, game_id):
     """Display details and all picks for a single game."""
     game = db.get_or_404(Game, game_id)
+    if game.is_cancelled:
+        flash("That game has been cancelled.", "warning")
+        return redirect(url_for(".main", year=year))
     # Determine if the week is locked based on the first game of that week
     first_game = (
         Game.query.filter_by(season=year, week=game.week)
+        .filter(Game.id.notin_(cancelled_game_ids()))
         .order_by(Game.start_timestamp)
         .first()
     )
@@ -314,6 +327,7 @@ def week(week_num, year):
         return render_template("games/post_season.html", year=year)
     first_game = (
         Game.query.filter_by(season=year, week=week_num)
+        .filter(Game.id.notin_(cancelled_game_ids()))
         .order_by(Game.start_timestamp)
         .first()
     )

--- a/ufa_picks/user/models.py
+++ b/ufa_picks/user/models.py
@@ -81,9 +81,12 @@ class User(UserMixin, PkModel):
         return f"{self.first_name} {self.last_name}"
 
     def _get_score_2025(self, year):
+        from ufa_picks.game.models import cancelled_game_ids
+
+        cancelled_ids = cancelled_game_ids()
         score = 0
         for p in self.picks:
-            if p.game.season == year:
+            if p.game.season == year and p.game_id not in cancelled_ids:
                 score += p.points
         return score
 
@@ -94,13 +97,22 @@ class User(UserMixin, PkModel):
 
     def get_weekly_breakdown(self, year):
         """Get a detailed breakdown of weekly scores, including the dropped week."""
-        from ufa_picks.game.models import Game
+        from ufa_picks.game.models import Game, cancelled_game_ids
+
+        # Cancelled games never go Final; exclude them so their week can still
+        # complete (and thus become a drop candidate) and so they never score.
+        cancelled_ids = cancelled_game_ids()
 
         # Identify all regular season weeks (1-13) that have already started/passed.
         now = dt.datetime.now(dt.timezone.utc).replace(tzinfo=None)
         active_weeks_query = (
             db.session.query(Game.week)
-            .filter(Game.season == year, Game.week <= 13, Game.start_timestamp <= now)
+            .filter(
+                Game.season == year,
+                Game.week <= 13,
+                Game.start_timestamp <= now,
+                Game.id.notin_(cancelled_ids),
+            )
             .distinct()
         )
         active_weeks = [w[0] for w in active_weeks_query.all()]
@@ -109,7 +121,12 @@ class User(UserMixin, PkModel):
         incomplete_weeks = {
             w[0]
             for w in db.session.query(Game.week)
-            .filter(Game.season == year, Game.week <= 13, Game.status != "Final")
+            .filter(
+                Game.season == year,
+                Game.week <= 13,
+                Game.status != "Final",
+                Game.id.notin_(cancelled_ids),
+            )
             .distinct()
             .all()
         }
@@ -120,7 +137,7 @@ class User(UserMixin, PkModel):
         playoff_scores = {}
 
         for p in self.picks:
-            if p.game.season == year:
+            if p.game.season == year and p.game_id not in cancelled_ids:
                 w = p.game.week
                 if w <= 13:
                     if w in reg_season_scores:
@@ -166,18 +183,30 @@ class User(UserMixin, PkModel):
 
     def get_weekly_score(self, year, week):
         """Get the user's score for a specific week."""
+        from ufa_picks.game.models import cancelled_game_ids
+
+        cancelled_ids = cancelled_game_ids()
         year = str(year)
         week = int(week)
         score = 0
         for p in self.picks:
-            if p.game.season == year and p.game.week == week:
+            if (
+                p.game.season == year
+                and p.game.week == week
+                and p.game_id not in cancelled_ids
+            ):
                 score += p.points
         return score
 
     def get_game_score(self, game_id):
         """Get the points earned for a specific game."""
+        from ufa_picks.game.models import cancelled_game_ids
+
+        game_id = str(game_id)
+        if game_id in cancelled_game_ids():
+            return 0
         for p in self.picks:
-            if p.game_id == str(game_id):
+            if p.game_id == game_id:
                 return p.points
         return 0
 


### PR DESCRIPTION
## Summary

Excludes cancelled games (starting with `2026-07-18-PIT-CHI`) from both the UI and scoring.

- Cancellations are tracked in a **new `cancelled_games` table** rather than on the `games` table. The external loader overwrites `games` (including `status`) on every run, so a status edit or deleted row would not survive a sync — this table is never touched by the loader, and future cancellations are a one-line `INSERT` (no PR needed).
- **Views** ([game/views.py](ufa_picks/game/views.py)): cancelled games are filtered out of the week list + week badges, the pre/post-lock pick pages, and the week-lock lookup. `game_details` redirects with a flash, and the `update_pick` API returns a 400.
- **Scoring** ([user/models.py](ufa_picks/user/models.py)): fixes `get_weekly_breakdown` treating a cancelled game's week as perpetually "incomplete" (which permanently blocked week 13 from ever becoming a drop candidate). Also guards `_get_score_2025`, `get_weekly_score`, and `get_game_score` so a cancelled game scores 0 even if it were ever marked Final.
- New model `CancelledGame` + `cancelled_game_ids()` helper + `Game.is_cancelled` ([game/models.py](ufa_picks/game/models.py)).
- Migration `c4f9a1b7d2e0` creates the table and seeds `2026-07-18-PIT-CHI`.

## Production migration

After deploy, run:

```
docker compose run --rm manage db upgrade
```

This creates `cancelled_games` and seeds the initial cancelled game in one step (the migration inserts the row).

## Test checklist

- [x] New `tests/test_cancelled_games.py` (6 tests) + `CancelledGameFactory`
- [x] A cancelled, never-Final game no longer blocks its week from completing/dropping
- [x] Contrast test: a *non-cancelled* Upcoming game still keeps its week incomplete (existing behavior preserved)
- [x] A cancelled game marked Final still scores 0 (`get_weekly_score` / `get_game_score`)
- [x] `game_details` for a cancelled game redirects away; `update_pick` returns 400
- [x] Cancelled game not listed on its week's picks page
- [x] Existing scoring tests still pass (`tests/test_scoring.py`)
- [x] Migration applied and verified against the dev DB (`is_cancelled` → `True`)

> Note: the repo's webtest-based view suite (`test_game_views.py`, `test_weekly_views.py`) currently fails to locate `loginForm` in the local env — confirmed pre-existing on `main`. The new view tests log in via the `/login/` route directly to avoid it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)